### PR TITLE
fix (script.js): clear table when rewriting to dos

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,40 +1,47 @@
 let todoItems = JSON.parse(localStorage.getItem('todoItems')) || [];
-const deleteAllCompletedTodosButton = document.getElementById(
-  'delete-all-completed-tasks-button'
-);
+initializeInputForm();
 
-deleteAllCompletedTodosButton.addEventListener('click', deleteAllCheckedTasks);
-const submitButton = document.getElementById('submit-button');
-submitButton.addEventListener('click', (e) => {
-  e.preventDefault();
+function initializeInputForm() {
+  document.getElementById('submit-button').addEventListener('click', (e) => {
+    e.preventDefault();
+    createToDo();
+  });
+  document
+    .getElementById('delete-all-completed-tasks-button')
+    .addEventListener('click', deleteAllCheckedTasks);
+}
+
+function createToDo() {
   const todoText = document.getElementById('toDoItemText').value;
-
   if (todoText.length > 0) {
     const task = {
       todoText,
       checked: false,
       id: todoItems.length > 0 ? todoItems[todoItems.length - 1].id + 1 : 1,
-      time: getDateString()
+      time: getDateString(),
     };
 
     addTodo(task);
-    // document.getElementById('form').reset();
   }
-});
-
-function addTodo(todo) {
-  addToDoItemToTable(todo);
-  todoItems.push(todo);
-  saveTodoItems(todoItems);
 }
 
-function saveTodoItems(array) {
+function addTodo(todo) {
+  todoItems.push(todo);
+  addToDoItemToTable(todo);
+  writeToDoToLocalStorage(todoItems);
+}
+
+function clearLocalStorage() {
+  localStorage.clear();
+}
+function writeToDoToLocalStorage(array) {
   localStorage.setItem('todoItems', JSON.stringify(array));
 }
 
-function createTableRow() {
+function createTableRow(id) {
   const tableRow = document.createElement('tr');
   tableRow.setAttribute('class', 'row');
+  tableRow.id = id;
   return tableRow;
 }
 
@@ -42,45 +49,47 @@ function createDeleteButton() {
   const deleteButton = document.createElement('button');
   deleteButton.textContent = 'X';
   deleteButton.setAttribute('class', 'delete');
-
   return deleteButton;
 }
 
-function addToDoItemToTable() {
-  if (document.getElementById('row0') != null) {
-    document.getElementById('resumeToDoTable').deleteRow(0);
-  }
+function clearToDoTable() {
+  const tableBody = document.getElementById('resumeToDoTable');
+  removeAllChildNodes(tableBody);
+}
+function addRowToTable(row) {
+  const table = document.getElementById('resumeToDoTable');
+  table.appendChild(row);
+}
 
+function addToDoItemToTable() {
+  clearToDoTable();
   for (let i = 0; i < todoItems.length; i++) {
-    const row = createTableRow();
-    row.id = todoItems[i].id;
-    const table = document.getElementById('resumeToDoTable');
-    table.appendChild(row);
-    const tableDateCell = document.createElement('td');
-    tableDateCell.textContent = todoItems[i].time;
+    const row = createTableRow(todoItems[i].id);
+    addRowToTable(row);
+    const date = document.createElement('td');
+    date.textContent = todoItems[i].time;
     const checkbox = document.createElement('input');
     checkbox.setAttribute('type', 'checkbox');
 
-    const toDoTextCell = document.createElement('td');
-    toDoTextCell.textContent = todoItems[i].todoText;
+    const toDoText = document.createElement('td');
+    toDoText.textContent = todoItems[i].todoText;
     const deleteButtonCell = document.createElement('td');
     const deleteButton = createDeleteButton();
-
-    row.appendChild(tableDateCell);
-    row.appendChild(checkbox);
-    row.appendChild(toDoTextCell);
     deleteButtonCell.appendChild(deleteButton);
+
+    row.appendChild(date);
+    row.appendChild(checkbox);
+    row.appendChild(toDoText);
     row.appendChild(deleteButtonCell);
 
     checkbox.addEventListener('click', () => {
       toggleTask(todoItems[i].id);
       if (todoItems[i].checked === true) {
-        toDoTextCell.style.textDecoration = 'line-through';
+        toDoText.style.textDecoration = 'line-through';
       }
     });
 
     deleteButton.addEventListener('click', (e) => {
-      e.stopPropagation();
       deleteSingleCheckedTask(deleteButton, todoItems[i].id);
     });
   }
@@ -100,25 +109,16 @@ function toggleTask(id) {
   }
 }
 
-function createDeleteButton() {
-  const deleteButton = document.createElement('button');
-  deleteButton.textContent = 'X';
-  deleteButton.setAttribute('class', 'delete');
-
-  return deleteButton;
-}
-
-const daylist = [
-  'Sunday',
-  'Monday',
-  'Tuesday',
-  'Wednesday ',
-  'Thursday',
-  'Friday',
-  'Saturday'
-];
-
 function getDateString() {
+  const daylist = [
+    'Sunday',
+    'Monday',
+    'Tuesday',
+    'Wednesday ',
+    'Thursday',
+    'Friday',
+    'Saturday',
+  ];
   const today = new Date();
   const dayOfWeek = today.getDay();
 
@@ -137,7 +137,9 @@ function deleteAllCheckedTasks() {
   todoItems = todoItems.filter((todoItem) => {
     return todoItem.checked === false;
   });
-  saveTodoItems(todoItems);
+
+  clearLocalStorage();
+  writeToDoToLocalStorage(todoItems);
   addToDoItemToTable();
 }
 
@@ -148,7 +150,12 @@ function deleteSingleCheckedTask(element, id) {
       todoItems.splice(i, 1);
     }
   }
-  saveTodoItems(todoItems);
+  writeToDoToLocalStorage(todoItems);
   addToDoItemToTable();
-  //renderTask();
+}
+
+function removeAllChildNodes(parent) {
+  while (parent.firstChild) {
+    parent.removeChild(parent.firstChild);
+  }
 }


### PR DESCRIPTION
Added a function that clears the DOM. When `addToDoItemToTable` is called, it is actually adding ALL the todos again. Added a function to the beginning that always clear the entire table prior to this happening. 